### PR TITLE
Change default formatString for Types.Datetime

### DIFF
--- a/fields/types/datetime/DatetimeType.js
+++ b/fields/types/datetime/DatetimeType.js
@@ -22,7 +22,7 @@ function datetime(list, path, options) {
 	this._properties = ['formatString'];
 	
 	this.typeDescription = 'date and time';
-	this.formatString = (options.format === false) ? false : (options.format || 'Do MMM YYYY');
+	this.formatString = (options.format === false) ? false : (options.format || 'YYYY-MM-DD h:m:s a');
 	
 	if (this.formatString && 'string' !== typeof this.formatString) {
 		throw new Error('FieldType.DateTime: options.format must be a string.');


### PR DESCRIPTION
The default display for the Types.Datetime field is only a date, as the control is technically for a date and time I kindly suggest that it should display both the date and the time. I found this issue when trying to display a create and modify date by using the nodes option on the field.
