### PR TITLE
Add delimiter option to the Keystone Select Field/Type

### DIFF
--- a/fields/types/Type.js
+++ b/fields/types/Type.js
@@ -87,7 +87,8 @@ Field.prototype.getOptions = function() {
 			'indent',
 			'hidden',
 			'collapse',
-			'dependsOn'
+			'dependsOn',
+			'delimiter'
 		];
 		
 		if (_.isArray(this._properties)) {

--- a/fields/types/select/SelectField.js
+++ b/fields/types/select/SelectField.js
@@ -32,7 +32,7 @@ module.exports = Field.create({
 		// TODO: This should be natively handled by the Select component
 		var ops = (this.props.numeric) ? this.props.ops.map(function(i) { return { label: i.label, value: String(i.value) }; }) : this.props.ops;
 		var value = ('number' === typeof this.props.value) ? String(this.props.value) : this.props.value;
-		if (this.props.delimiter !== undefined && this.props.delimiter !== "") {
+		if (this.props.delimiter !== undefined && this.props.delimiter !== '') {
 			return <Select name={this.props.path} value={value} options={ops} onChange={this.valueChanged} delimiter={this.props.delimiter} />;
 		} else {
 			return <Select name={this.props.path} value={value} options={ops} onChange={this.valueChanged} />;	

--- a/fields/types/select/SelectField.js
+++ b/fields/types/select/SelectField.js
@@ -32,7 +32,11 @@ module.exports = Field.create({
 		// TODO: This should be natively handled by the Select component
 		var ops = (this.props.numeric) ? this.props.ops.map(function(i) { return { label: i.label, value: String(i.value) }; }) : this.props.ops;
 		var value = ('number' === typeof this.props.value) ? String(this.props.value) : this.props.value;
-		return <Select name={this.props.path} value={value} options={ops} onChange={this.valueChanged} />;	
+		if (this.props.delimiter !== undefined && this.props.delimiter !== "") {
+			return <Select name={this.props.path} value={value} options={ops} onChange={this.valueChanged} delimiter={this.props.delimiter} />;
+		} else {
+			return <Select name={this.props.path} value={value} options={ops} onChange={this.valueChanged} />;	
+		}
 	}
 	
 });

--- a/fields/types/select/SelectType.js
+++ b/fields/types/select/SelectType.js
@@ -49,6 +49,10 @@ function select(list, path, options) {
 	// ensure this.emptyOption is a boolean
 	this.emptyOption = options.emptyOption ? true : false;
 	
+	if (options.delimiter !== undefined) {
+		this.delimiter = options.delimiter;
+	}
+	
 	// cached maps for options, labels and values
 	this.map = utils.optionsMap(this.ops);
 	this.labels = utils.optionsMap(this.ops, 'label');


### PR DESCRIPTION
This allows delimiters to be passed in to the <code><a href="https://github.com/JedWatson/react-select">react-select</a></code> control from a Keystone List model when using a type of <code>Types.Select</code> with <code>options</code> values containing ",". 

ex.
User.add(
{
...
        income: {
            type: Types.Select,
            delimiter: '|',
            options: [
                {value: 'Less than $20,000', label: 'Less than $20,000'},
                {value: '$20,000 to $49,999', label: '$20,000 to $49,999'},
                {value: '$50,000 to $79,999', label: '$50,000 to $79,999'},
                {value: '$80,000 to $99,999', label: '$80,000 to $99,999'},
                {value: '$100,000 to $149,999', label: '$100,000 to $149,999'},
                {value: '$150,000 or more', label: '$150,000 or more'}
            ]
        },
...
});
